### PR TITLE
Update crate version to allow use in keyring crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "db-keystore"
-version = "0.4.2-pre.1"
+version = "0.4.2-pre.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -976,9 +976,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc89deee4af0429081d2a518c0431ae068222a5a262a3bc6ff4d8535ec2e02fe"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
 dependencies = [
  "cc",
 ]
@@ -1091,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.49"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aca3c01a711f395b4257b81674c0e90e8dd1f1e62c4b7db45f684cc7a4fcb18a"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
 dependencies = [
  "libmimalloc-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "db-keystore"
-version = "0.4.2-pre.1"
+version = "0.4.2-pre.2"
 edition = "2024"
 authors = ["Steve Schoettler <stevelr-git@pm.me>"]
 description = "SQLite-backed credential store for the `keyring-core` API"


### PR DESCRIPTION
The keyring crate is updating to depend on keyring-core v1.0. This means that it needs a release of db-keystore that also depends on v1.0.