### PR TITLE
v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
-## [Unreleased]
+## 0.4.4
 
-### Added
+**Added**
 
-- Public library API `DbKeyStore::rekey(source_path, source_opts, dest_path, dest_opts) -> Result<RekeyOutcome>` for out-of-place rekey (add/remove/rotate the on-disk encryption key). It reads every credential from the source database and writes it into a freshly created destination, preserving `service`, `user`, `uuid`, and `comment`, and mirroring `(service, user)` uniqueness detected from the source schema. The source database is left fully intact, so callers can verify the destination before retiring the source. Returns `RekeyOutcome { copied }`; no secret material appears in the result or its `Debug`.
-- The `db-keystore rekey` CLI subcommand now delegates to `DbKeyStore::rekey`, so there is a single rekey implementation shared by the library and the CLI.
+- Public rekey api `DbKeyStore::rekey`. Moved functionality from cli to library
+  so it can be used programmatically.
+  Use to change encryption key, add encryption, or remove encryption.
+  Requires quiescent database.
+
+**Changed**
+
+- Bumped turso dependency from 0.6.1 to 0.7.0
 
 ## [0.4.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [Unreleased]
+
+### Added
+
+- Public library API `DbKeyStore::rekey(source_path, source_opts, dest_path, dest_opts) -> Result<RekeyOutcome>` for out-of-place rekey (add/remove/rotate the on-disk encryption key). It reads every credential from the source database and writes it into a freshly created destination, preserving `service`, `user`, `uuid`, and `comment`, and mirroring `(service, user)` uniqueness detected from the source schema. The source database is left fully intact, so callers can verify the destination before retiring the source. Returns `RekeyOutcome { copied }`; no secret material appears in the result or its `Debug`.
+- The `db-keystore rekey` CLI subcommand now delegates to `DbKeyStore::rekey`, so there is a single rekey implementation shared by the library and the CLI.
+
 ## [0.4.3]
 
 **Changed**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "aegis"
-version = "0.9.12"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e07d39d15384924b35b70d7b8fa1f9a2934101dd3fa4722ede163cc4f9b7b960"
+checksum = "58541132f980da31e9aa99f7bdee69bc84bf1e168b9b91ef2dbe8abb7b4ce5dd"
 dependencies = [
  "cc",
  "softaes",
@@ -55,6 +55,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
 
 [[package]]
 name = "android_system_properties"
@@ -117,15 +123,15 @@ dependencies = [
 
 [[package]]
 name = "antithesis_sdk"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dbd97a5b6c21cc9176891cf715f7f0c273caf3959897f43b9bd1231939e675"
+checksum = "08410fcac93669a476c006cd6c4512ac1e2b30fd117231a5d55d8a2c76599b82"
 dependencies = [
  "libc",
  "libloading",
  "linkme",
  "once_cell",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rustc_version_runtime",
  "serde",
  "serde_json",
@@ -133,17 +139,37 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "aristo"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcdeefa800110050103e2459a2f8dbdbd560ad046e30f1f87e24ce19c2cb8bde"
+dependencies = [
+ "aristo-macros",
+]
+
+[[package]]
+name = "aristo-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64a66d21a80182b35b1741997a6d2456911f54b7eb1918aa4e2382fc205268d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -202,15 +228,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -235,18 +261,18 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -261,15 +287,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "shlex 2.0.1",
@@ -292,9 +318,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "cfg_block"
@@ -338,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -348,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -417,37 +443,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-skiplist"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
-dependencies = [
- "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -471,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "db-keystore"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -492,8 +508,16 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
- "powerfmt",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -504,28 +528,23 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
+ "regex",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "env_filter",
  "log",
 ]
-
-[[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -565,12 +584,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "funty"
@@ -731,15 +744,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -757,21 +768,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -835,21 +831,137 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
+name = "icu_collator"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+checksum = "8bbdf98e5e0aa827770acee171ebb568aaab975a36b56afdb5fd0e2f525750bb"
+dependencies = [
+ "icu_collator_data",
+ "icu_collections",
+ "icu_locale",
+ "icu_locale_core",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "zerovec",
+]
 
 [[package]]
-name = "indexmap"
-version = "2.14.0"
+name = "icu_collator_data"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "038ed8e5817f2059c2f3efb0945ba78d060d3d25e8f1a1bea5139f821a21a2f0"
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
- "equivalent",
- "hashbrown 0.17.1",
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
  "serde",
- "serde_core",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]
@@ -872,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
+checksum = "9080b15e63775b9a2ac7dca720f7050a8b955e092ea0f6020a4a80f69998cdc0"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -913,9 +1025,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -942,12 +1054,6 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1013,6 +1119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,9 +1135,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loom"
@@ -1051,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -1122,9 +1234,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1249,6 +1361,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "serde_core",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1334,9 +1457,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1345,9 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -1402,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.1"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
 dependencies = [
  "rustversion",
 ]
@@ -1420,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1432,9 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1465,9 +1588,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -1516,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -1626,7 +1749,7 @@ dependencies = [
  "generator",
  "hex",
  "owo-colors",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rand_core 0.6.4",
  "rand_pcg",
  "scoped-tls",
@@ -1657,15 +1780,21 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "softaes"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e14297decde697ddf377c25752aead0927d5cfc89c2684d2af96901a4ceeea"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -1709,13 +1838,24 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1731,7 +1871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -1759,21 +1899,20 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -1783,18 +1922,29 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "serde_core",
+ "zerovec",
 ]
 
 [[package]]
@@ -1873,9 +2023,9 @@ dependencies = [
 
 [[package]]
 name = "turso"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832bb70436d4b4d3ed45285c5c6abd62328d5e2486297b32cf2b0812abeba6d4"
+checksum = "cac8d131650c1bf6a2721202208b3dfba218be25c975f48bebda766173fbdc3b"
 dependencies = [
  "mimalloc",
  "thiserror",
@@ -1888,15 +2038,17 @@ dependencies = [
 
 [[package]]
 name = "turso_core"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba8ef95330369724a1829b20dc1b728d644eaeb051891971b5d2b5617337a84b"
+checksum = "a77f2106de5a3014261be18283999fde0d06c24ae5d4cb85a6eff1aaeaff453d"
 dependencies = [
  "aegis",
  "aes",
  "aes-gcm",
+ "allocator-api2",
  "antithesis_sdk",
  "arc-swap",
+ "aristo",
  "bigdecimal",
  "bitflags",
  "branches",
@@ -1906,11 +2058,14 @@ dependencies = [
  "cfg_block",
  "chrono",
  "crc32c",
- "crossbeam-skiplist",
+ "crossbeam-epoch",
+ "crossbeam-utils",
  "either",
  "fallible-iterator",
  "fastbloom",
  "hex",
+ "icu_collator",
+ "icu_locale",
  "intrusive-collections",
  "io-uring",
  "libc",
@@ -1924,12 +2079,12 @@ dependencies = [
  "parking_lot",
  "pastey",
  "polling",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rapidhash",
  "regex",
  "regex-syntax",
  "roaring",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "rustix 1.1.4",
  "ryu",
  "serde_json",
@@ -1953,20 +2108,20 @@ dependencies = [
 
 [[package]]
 name = "turso_ext"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a47927d766b9ae7e3adf092d5e150dce80533615edc502641797878f190080"
+checksum = "48d367d863b095a9893690fc6c52bbf27edf422c135a58ba5ed2b03dbec8faac"
 dependencies = [
  "chrono",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "turso_macros",
 ]
 
 [[package]]
 name = "turso_macros"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0cdc6ae079c61aa21a89b595a4d0e19d9d848a2658542252e82f930c57c3d87"
+checksum = "1a817815d9ca218cb971ed2a0a41a89a5160966b5b4bd103c82792fd2f230f1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1975,9 +2130,9 @@ dependencies = [
 
 [[package]]
 name = "turso_parser"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b94707e5605411cddbd5a1bd6cc2d6b72181b02223b36b37ba350ed6b71877"
+checksum = "4ad90c0e6eea7ab131214804c70edad5372acecdcad8d4ccc75b0ded55b0df8f"
 dependencies = [
  "bitflags",
  "memchr",
@@ -1990,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "turso_sdk_kit"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a86ce113e5dcedeaad7809d9fa1dc00f837f40ccd8012ac1d2144c57672a34"
+checksum = "ea1abf8f42cf5c40f9777982c8dfda776242397250eb48f99d524c383b1b641a"
 dependencies = [
  "bindgen",
  "env_logger",
@@ -2001,14 +2156,15 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "turso_core",
+ "turso_ext",
  "turso_sdk_kit_macros",
 ]
 
 [[package]]
 name = "turso_sdk_kit_macros"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6ee03a3dc5a48a7a63ddd2c8f41aa7bb5195eb96f6a29831447c8cb3d841a"
+checksum = "372ce1889d2729223886f805638a4357f389756d6b64e26487af5a78b3e92e2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2017,12 +2173,13 @@ dependencies = [
 
 [[package]]
 name = "turso_sync_engine"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c58fe60f17b694f91bd278e93aceca10fb340950f6a8f1aedef11c28b50c4b8"
+checksum = "4157da3af3730e3cf5109668dc29b58b673f99fbbac3db3a682a4b87d56b9c4a"
 dependencies = [
  "base64",
  "bytes",
+ "crc32c",
  "genawaiter",
  "http",
  "libc",
@@ -2039,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "turso_sync_sdk_kit"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4512c7b28bb3bc09be1ba480ee60234ed9bbeb6686c9348323589ffcec504b93"
+checksum = "5fa3b4dee7f50c671ca757d1ac1ea7c99a7a9dec819a98bb1ad6a055e7d0234f"
 dependencies = [
  "bindgen",
  "env_logger",
@@ -2062,7 +2219,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.9.5",
 ]
 
 [[package]]
@@ -2093,12 +2250,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,6 +2260,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,11 +2279,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "sha1_smol",
  "wasm-bindgen",
@@ -2146,27 +2309,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2177,9 +2331,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2187,9 +2341,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2200,45 +2354,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -2396,97 +2516,21 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
+name = "write16"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
+name = "writeable"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -2498,19 +2542,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.52"
+name = "yoke"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2518,13 +2585,69 @@ dependencies = [
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.8.2"
+name = "zerofrom"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "serde",
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "db-keystore"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 authors = ["Steve Schoettler <stevelr-git@pm.me>"]
-description = "SQLite-backed credential store for the `keyring-core` API"
+description = "Encrypted SQLite credential store for the `keyring-core` API, backed by turso"
 repository = "https://github.com/stevelr/db-keystore"
 homepage = "https://github.com/stevelr/db-keystore"
 license = "MIT or Apache-2.0"
@@ -27,7 +27,7 @@ log = "0.4.29"
 regex = "1.12.3"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-turso = { version = "0.6.1", default-features = false, features = ["mimalloc"] }
+turso = { version = "0.7.0", default-features = false, features = ["mimalloc"] }
 uuid = { version = "1.22.0", features = ["v7"] }
 zeroize = "1.8.2"
 

--- a/bin/db-keystore.rs
+++ b/bin/db-keystore.rs
@@ -26,7 +26,7 @@
 //!
 use anyhow::{Context, Result, bail, ensure};
 use clap::{Args, Parser, Subcommand};
-use db_keystore::{DbKeyStore, DbKeyStoreConfig, EncryptionOpts};
+use db_keystore::{DbKeyStore, EncryptionOpts};
 use keyring_core::{Entry, Error as KeyringError, api::CredentialStoreApi};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -224,33 +224,25 @@ fn cmd_rekey(
         args.output.display()
     );
 
-    let store = open_store(&resolved_path, &cipher_opts)?;
-    let encrypted = store.is_encrypted();
-
     let new_cipher_opts = validate_cipher_and_key(args.new_cipher, args.new_hexkey)?;
-    if !encrypted && new_cipher_opts.is_none() {
+    if cipher_opts.is_none() && new_cipher_opts.is_none() {
         bail!("database is not encrypted; --new-cipher and --new-hexkey are required");
     }
 
-    let allow_ambiguity = detect_allow_ambiguity(&resolved_path, &cipher_opts)?;
-
-    let encryption_opts = new_cipher_opts
+    let source_opts = cipher_opts
         .as_ref()
         .map(|(cipher, hexkey)| EncryptionOpts::new(cipher.clone(), hexkey.as_str().to_string()));
-    let config = DbKeyStoreConfig {
-        path: args.output.clone(),
-        allow_ambiguity,
-        encryption_opts,
-        ..Default::default()
-    };
-    let new_store = DbKeyStore::new(config).context("failed to create new keystore")?;
+    let dest_opts = new_cipher_opts
+        .as_ref()
+        .map(|(cipher, hexkey)| EncryptionOpts::new(cipher.clone(), hexkey.as_str().to_string()));
 
-    let entries = store
-        .search(&HashMap::new())
-        .context("failed to read entries for rekey")?;
-    for entry in entries {
-        copy_entry(&entry, &new_store)?;
-    }
+    let outcome = DbKeyStore::rekey(&resolved_path, source_opts, &args.output, dest_opts)
+        .context("rekey failed")?;
+    eprintln!(
+        "rekeyed {} credential(s) to '{}'",
+        outcome.copied,
+        args.output.display()
+    );
 
     Ok(0)
 }
@@ -418,40 +410,6 @@ fn delete_by_service_user(store: &DbKeyStore, service: &str, user: &str) -> Resu
 fn normalize_uuid(value: &str) -> Result<String> {
     let uuid = uuid::Uuid::parse_str(value).context("invalid uuid format")?;
     Ok(uuid.to_string())
-}
-
-fn copy_entry(entry: &Entry, new_store: &DbKeyStore) -> Result<()> {
-    let (service, user) = entry
-        .get_specifiers()
-        .context("entry missing service/user")?;
-    let attrs = entry.get_attributes()?;
-    let uuid = attrs.get("uuid").cloned().context("entry missing uuid")?;
-    let comment = attrs.get("comment").cloned();
-
-    let mut mods: HashMap<&str, &str> = HashMap::new();
-    mods.insert("uuid", uuid.as_str());
-    if let Some(comment) = comment.as_deref() {
-        mods.insert("comment", comment);
-    }
-
-    let new_entry = new_store.build(service.as_str(), user.as_str(), Some(&mods))?;
-
-    let secret = Zeroizing::new(entry.get_secret()?);
-    new_entry.set_secret(secret.as_slice())?;
-    Ok(())
-}
-
-fn detect_allow_ambiguity(
-    path: &Path,
-    cipher_opts: &Option<(String, Zeroizing<String>)>,
-) -> Result<bool> {
-    let conn = open_conn(path, cipher_opts.as_ref())?;
-    let has_unique_index = find_unique_service_user_index(&conn)?.is_some();
-    if has_unique_index {
-        return Ok(false);
-    }
-    let has_table_unique = table_has_unique_service_user(&conn)?;
-    Ok(!has_table_unique)
 }
 
 fn open_conn(path: &Path, cipher_opts: Option<&(String, Zeroizing<String>)>) -> Result<Connection> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,7 +241,7 @@ impl DbKeyStore {
                     .build()
                     .await
             }))?;
-            let id = format!("DbKeyStore v{CRATE_VERSION} in-memory @ {start_time}",);
+            let id = format!("DbKeyStore v{CRATE_VERSION} in-memory @ {start_time}");
             let conn = map_turso(db.connect())?;
             (
                 DbKeyStore {
@@ -351,6 +351,142 @@ impl DbKeyStore {
     /// Returns path to database file
     pub fn path(&self) -> String {
         self.inner.path.clone()
+    }
+
+    /// Rekey a keystore out-of-place: read every credential from the source
+    /// database and write it into a freshly created destination database.
+    ///
+    /// This is used to add, remove, or rotate the on-disk encryption key (a DEK
+    /// rotation): pass `dest_opts = Some(..)` to add or rotate encryption, or
+    /// `dest_opts = None` to write an unencrypted copy. `source_opts` must
+    /// supply the cipher/key the source was written with (or `None` if the
+    /// source is unencrypted).
+    ///
+    /// The operation is non-destructive to the source: the source database is
+    /// opened read-only-ish (no rows are mutated) and left fully intact, and the
+    /// destination is fully written before returning. Callers that own a
+    /// verify-then-swap-then-delete sequence (for example secret-vault
+    /// rotate-dek) should treat the returned destination as the new candidate
+    /// and only retire the source after independently verifying it.
+    ///
+    /// Each credential is copied with its `service`, `user`, `uuid`, `comment`,
+    /// and `secret` preserved. Whether the source enforced `(service, user)`
+    /// uniqueness is detected from the source schema and mirrored on the
+    /// destination so ambiguous keystores round-trip unchanged.
+    ///
+    /// `dest_path` must not already exist. Returns a [`RekeyOutcome`] describing
+    /// how many credentials were copied. No secret material is logged or
+    /// included in any returned value.
+    pub fn rekey(
+        source_path: impl AsRef<Path>,
+        source_opts: Option<EncryptionOpts>,
+        dest_path: impl AsRef<Path>,
+        dest_opts: Option<EncryptionOpts>,
+    ) -> Result<RekeyOutcome> {
+        let source_path = source_path.as_ref();
+        let dest_path = dest_path.as_ref();
+
+        if !source_path.is_file() {
+            return Err(Error::NoStorageAccess(Box::new(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("no source database at '{}'", source_path.display()),
+            ))));
+        }
+        if dest_path.exists() {
+            return Err(Error::Invalid(
+                "dest_path".to_string(),
+                format!("destination path '{}' already exists", dest_path.display()),
+            ));
+        }
+
+        let source = DbKeyStore::new(DbKeyStoreConfig {
+            path: source_path.to_path_buf(),
+            encryption_opts: source_opts,
+            // open permissively so we can read ambiguous keystores; uniqueness
+            // is detected from the schema below and mirrored on the destination.
+            allow_ambiguity: true,
+            ..Default::default()
+        })?;
+
+        let allow_ambiguity = source.detect_allow_ambiguity()?;
+
+        let dest = DbKeyStore::new(DbKeyStoreConfig {
+            path: dest_path.to_path_buf(),
+            encryption_opts: dest_opts,
+            allow_ambiguity,
+            ..Default::default()
+        })?;
+
+        let entries = source.read_all_for_rekey()?;
+        let copied = entries.len();
+        for entry in &entries {
+            dest.write_for_rekey(entry)?;
+        }
+
+        Ok(RekeyOutcome { copied })
+    }
+
+    /// Detect whether the source schema enforces `(service, user)` uniqueness.
+    /// Returns `true` if ambiguous entries are permitted (no unique constraint).
+    fn detect_allow_ambiguity(&self) -> Result<bool> {
+        let conn = self.inner.connect()?;
+        let has_unique = map_turso(block_on(schema_has_unique_service_user(&conn)))?;
+        Ok(!has_unique)
+    }
+
+    /// Read every credential (including secret) for an out-of-place rekey copy.
+    fn read_all_for_rekey(&self) -> Result<Vec<RekeyRecord>> {
+        let conn = self.inner.connect()?;
+        map_turso(block_on(query_all_for_rekey(&conn)))
+    }
+
+    /// Insert one credential into this (destination) store, preserving its
+    /// service, user, uuid, comment, and secret.
+    fn write_for_rekey(&self, record: &RekeyRecord) -> Result<()> {
+        validate_service_user(&record.service, &record.user)?;
+        validate_secret(&record.secret)?;
+        let credential = DbKeyCredential {
+            inner: Arc::clone(&self.inner),
+            id: CredId {
+                service: record.service.clone(),
+                user: record.user.clone(),
+            },
+            uuid: Some(normalize_uuid_input(&record.uuid)?),
+            comment: record.comment.clone(),
+        };
+        credential.set_secret(record.secret.as_slice())
+    }
+}
+
+/// Result of a [`DbKeyStore::rekey`] operation.
+///
+/// Intentionally carries no secret material so it is safe to log or format.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct RekeyOutcome {
+    /// Number of credentials copied from source to destination.
+    pub copied: usize,
+}
+
+/// One credential read from the source during rekey. The `secret` is held in a
+/// `Zeroizing` buffer so it is wiped from the heap when the record is dropped.
+struct RekeyRecord {
+    service: String,
+    user: String,
+    uuid: String,
+    comment: Option<String>,
+    secret: Zeroizing<Vec<u8>>,
+}
+
+impl fmt::Debug for RekeyRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // never expose the secret in Debug output
+        f.debug_struct("RekeyRecord")
+            .field("service", &self.service)
+            .field("user", &self.user)
+            .field("uuid", &self.uuid)
+            .field("comment", &self.comment)
+            .field("secret", &"<redacted>")
+            .finish()
     }
 }
 
@@ -1002,6 +1138,64 @@ async fn query_all_credentials(
         results.push((CredId { service, user }, uuid, comment));
     }
     Ok(results)
+}
+
+/// Read every credential, including its secret, for an out-of-place rekey copy.
+async fn query_all_for_rekey(conn: &Connection) -> turso::Result<Vec<RekeyRecord>> {
+    let mut rows = conn
+        .query(
+            "SELECT service, user, uuid, secret, comment FROM credentials",
+            (),
+        )
+        .await?;
+    let mut results = Vec::new();
+    while let Some(row) = rows.next().await? {
+        let service = value_to_string(row.get_value(0)?, "service")?;
+        let user = value_to_string(row.get_value(1)?, "user")?;
+        let uuid = value_to_string(row.get_value(2)?, "uuid")?;
+        let secret = value_to_secret(row.get_value(3)?, "secret")?;
+        let comment = value_to_option_string(row.get_value(4)?, "comment")?;
+        results.push(RekeyRecord {
+            service,
+            user,
+            uuid,
+            comment,
+            secret,
+        });
+    }
+    Ok(results)
+}
+
+/// Returns true if the `credentials` schema enforces `(service, user)`
+/// uniqueness, either via a unique index or a table-level unique constraint.
+async fn schema_has_unique_service_user(conn: &Connection) -> turso::Result<bool> {
+    let mut rows = conn
+        .query(
+            "SELECT sql FROM sqlite_master \
+             WHERE (type = 'index' AND tbl_name = 'credentials') \
+                OR (type = 'table' AND name = 'credentials') \
+             AND sql IS NOT NULL",
+            (),
+        )
+        .await?;
+    while let Some(row) = rows.next().await? {
+        match row.get_value(0)? {
+            Value::Text(sql) if is_unique_service_user_sql(sql.as_str()) => return Ok(true),
+            _ => {}
+        }
+    }
+    Ok(false)
+}
+
+/// True if a `sqlite_master.sql` definition enforces uniqueness on
+/// `(service, user)` (whitespace/quote/case insensitive).
+fn is_unique_service_user_sql(sql: &str) -> bool {
+    let normalized: String = sql
+        .chars()
+        .filter(|c| !c.is_whitespace() && *c != '"' && *c != '`')
+        .flat_map(char::to_lowercase)
+        .collect();
+    normalized.contains("unique") && normalized.contains("(service,user)")
 }
 
 async fn fetch_uuids(conn: &Connection, id: &CredId) -> turso::Result<Vec<String>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -730,7 +730,7 @@ impl DbKeyCredential {
                     // if ambiguity is not allowed, unique index should have prevented this case
                     return Err(Error::PlatformFailure(format!(
                         "Database is in an invalid state: ambiguity not allowed, but multiple entries found for {:?}",
-                        &self.id
+                        self.id
                     ).into()));
                 }
             }
@@ -880,7 +880,7 @@ impl CredentialApi for DbKeyCredential {
             self.get_attributes()?;
             return Ok(());
         }
-        let comment = comment.and_then(|value| if value.is_empty() { None } else { Some(value) });
+        let comment = comment.filter(|value| !value.is_empty());
         let make_comment_value = || comment_value(comment.as_ref());
         let conn = self.inner.connect()?;
         block_on(async {

--- a/tests/vfs_encryption.rs
+++ b/tests/vfs_encryption.rs
@@ -5,6 +5,8 @@ use keyring_core::api::CredentialStoreApi;
 use zeroize::Zeroizing;
 
 const HEXKEY_256: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+// distinct N+1 key for rotation tests
+const HEXKEY_256_B: &str = "ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100";
 
 #[test]
 fn encryption_round_trip_requires_key() {
@@ -65,6 +67,183 @@ fn vfs_memory_is_accepted() {
     entry.set_password(password.as_str()).expect("set_password");
     let value = Zeroizing::new(entry.get_password().expect("get_password"));
     assert_eq!(value.as_str(), "dromomeryx");
+}
+
+fn open_encrypted(path: &std::path::Path, hexkey: &str) -> DbKeyStore {
+    let config = DbKeyStoreConfig {
+        path: path.to_path_buf(),
+        encryption_opts: Some(EncryptionOpts::new("aes256gcm", hexkey)),
+        ..Default::default()
+    };
+    // DbKeyStore::new returns Arc<DbKeyStore>; deref+clone for an owned value
+    (*DbKeyStore::new(config).expect("open encrypted store")).clone()
+}
+
+fn password_of(store: &DbKeyStore, service: &str, user: &str) -> String {
+    let results = store
+        .search(&HashMap::from([("service", service), ("user", user)]))
+        .expect("search");
+    assert_eq!(results.len(), 1, "expected exactly one {service}/{user}");
+    Zeroizing::new(results[0].get_password().expect("get_password"))
+        .as_str()
+        .to_string()
+}
+
+// rotate-dek N -> N+1: every credential decrypts under the new key and matches
+// the source; the source remains readable under the old key; the wrong
+// destination key fails closed.
+#[test]
+fn rekey_rotates_dek_out_of_place() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("seq-n.db");
+    let dst = dir.path().join("seq-n+1.db");
+
+    // seed the source (sequence N) with several credentials, one with a comment
+    {
+        let store = open_encrypted(&src, HEXKEY_256);
+        for (svc, user, pw) in [("svc-a", "alice", "pw-a"), ("svc-b", "bob", "pw-b")] {
+            let entry = store.build(svc, user, None).expect("build");
+            entry.set_password(pw).expect("set_password");
+        }
+        let commented = store
+            .build(
+                "svc-c",
+                "carol",
+                Some(&HashMap::from([("comment", "note-c")])),
+            )
+            .expect("build commented");
+        commented.set_password("pw-c").expect("set_password");
+    }
+
+    // rotate to sequence N+1 under a new key
+    let outcome = DbKeyStore::rekey(
+        &src,
+        Some(EncryptionOpts::new("aes256gcm", HEXKEY_256)),
+        &dst,
+        Some(EncryptionOpts::new("aes256gcm", HEXKEY_256_B)),
+    )
+    .expect("rekey");
+    assert_eq!(outcome.copied, 3, "all three credentials copied");
+    assert!(src.is_file(), "source left intact");
+    assert!(dst.is_file(), "destination written");
+
+    // destination decrypts under the NEW key and matches the source values
+    {
+        let store = open_encrypted(&dst, HEXKEY_256_B);
+        assert_eq!(password_of(&store, "svc-a", "alice"), "pw-a");
+        assert_eq!(password_of(&store, "svc-b", "bob"), "pw-b");
+        assert_eq!(password_of(&store, "svc-c", "carol"), "pw-c");
+        // comment-JSON attribute preserved across rekey
+        let results = store
+            .search(&HashMap::from([("service", "svc-c"), ("user", "carol")]))
+            .expect("search");
+        let attrs = results[0].get_attributes().expect("get_attributes");
+        assert_eq!(attrs.get("comment"), Some(&"note-c".to_string()));
+        assert!(attrs.contains_key("uuid"));
+    }
+
+    // source still readable under the OLD key
+    {
+        let store = open_encrypted(&src, HEXKEY_256);
+        assert_eq!(password_of(&store, "svc-a", "alice"), "pw-a");
+    }
+
+    // wrong destination key fails closed (no plaintext leak)
+    {
+        let config = DbKeyStoreConfig {
+            path: dst.clone(),
+            encryption_opts: Some(EncryptionOpts::new("aes256gcm", HEXKEY_256)),
+            ..Default::default()
+        };
+        let result = std::panic::catch_unwind(|| DbKeyStore::new(config));
+        assert!(
+            matches!(result, Ok(Err(_)) | Err(_)),
+            "opening rekeyed db with the old (wrong) key must fail"
+        );
+    }
+}
+
+// rekey can add encryption to a plaintext source and remove it from an
+// encrypted source; the source is never mutated in place.
+#[test]
+fn rekey_adds_and_removes_encryption() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let plain = dir.path().join("plain.db");
+    let encrypted = dir.path().join("encrypted.db");
+    let decrypted = dir.path().join("decrypted.db");
+
+    {
+        let store = (*DbKeyStore::new(DbKeyStoreConfig {
+            path: plain.clone(),
+            ..Default::default()
+        })
+        .expect("plain store"))
+        .clone();
+        let entry = store.build("svc", "user", None).expect("build");
+        entry.set_password("secret").expect("set_password");
+    }
+
+    // add encryption (plaintext source, encrypted dest)
+    let outcome = DbKeyStore::rekey(
+        &plain,
+        None,
+        &encrypted,
+        Some(EncryptionOpts::new("aes256gcm", HEXKEY_256)),
+    )
+    .expect("add encryption");
+    assert_eq!(outcome.copied, 1);
+    assert_eq!(
+        password_of(&open_encrypted(&encrypted, HEXKEY_256), "svc", "user"),
+        "secret"
+    );
+
+    // remove encryption (encrypted source, plaintext dest)
+    let outcome = DbKeyStore::rekey(
+        &encrypted,
+        Some(EncryptionOpts::new("aes256gcm", HEXKEY_256)),
+        &decrypted,
+        None,
+    )
+    .expect("remove encryption");
+    assert_eq!(outcome.copied, 1);
+    let store = (*DbKeyStore::new(DbKeyStoreConfig {
+        path: decrypted.clone(),
+        ..Default::default()
+    })
+    .expect("plain dest"))
+    .clone();
+    assert_eq!(password_of(&store, "svc", "user"), "secret");
+}
+
+// rekey refuses to overwrite an existing destination.
+#[test]
+fn rekey_refuses_existing_destination() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("src.db");
+    let dst = dir.path().join("dst.db");
+
+    for path in [&src, &dst] {
+        let store = (*DbKeyStore::new(DbKeyStoreConfig {
+            path: path.clone(),
+            ..Default::default()
+        })
+        .expect("store"))
+        .clone();
+        let entry = store.build("svc", "user", None).expect("build");
+        entry.set_password("pw").expect("set_password");
+    }
+
+    let err = DbKeyStore::rekey(
+        &src,
+        None,
+        &dst,
+        Some(EncryptionOpts::new("aes256gcm", HEXKEY_256)),
+    )
+    .expect_err("must refuse existing destination");
+    assert!(
+        format!("{err:?}").contains("already exists"),
+        "unexpected error: {err:?}"
+    );
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
- bump turso dependency to 0.7.0
- add public rekey api (Moved functionality from cli to lib)
- fixed rust 1.97.0 clippy warnings